### PR TITLE
Improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "softmew"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softmew"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/src/bin/gamozo_test.rs
+++ b/src/bin/gamozo_test.rs
@@ -1,0 +1,18 @@
+// Test empty reset 100 million times.
+//
+// Gamozo was able to get this down to about 125 milliseconds.
+
+use softmew::MMU;
+use softmew::map::Perm;
+
+pub fn main() {
+    let mut mew = MMU::new();
+    mew.map_memory(0x100, 0x104, Perm::default()).unwrap();
+    let data = mew.get_mapping_mut(0x100).unwrap();
+    data.data_mut().copy_from_slice(b"asdf");
+
+    let forked = mew.clone();
+    for _ in 0..100_000_000 {
+        mew.reset(&forked);
+    }
+}

--- a/src/bin/gamozo_test2.rs
+++ b/src/bin/gamozo_test2.rs
@@ -1,0 +1,19 @@
+// Test writing and resetting a memory mapping 100 million times
+//
+// Gamozo was ble to get this down to about 900 milliseconds.
+
+use softmew::MMU;
+use softmew::map::Perm;
+
+pub fn main() {
+    let mut mew = MMU::new();
+    mew.map_memory(0x0, 1024 * 1024, Perm::default()).unwrap();
+    let data = mew.get_mapping_mut(0x100).unwrap();
+    data.data_mut()[0..4].copy_from_slice(b"asdf");
+
+    let forked = mew.clone();
+    for _ in 0..100_000_000 {
+        mew.write_perm(0x100, b"hello").unwrap();
+        mew.reset(&forked);
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,16 @@
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Range};
 use crate::fault::{Fault, Reason};
 
-const PAGE_SIZE: usize = 4096;
+/// This will control the size of a dirty block
+///
+/// Resetting works on blocks of memory and this controls that block size. Every time a write
+/// happens, the map will keep track of which blocks have been dirtied. Then on a reset every block
+/// will be reset to the original data. A write of any size to a block will dirty it so this
+/// parameter can change the performance of resetting a lot.
+///
+/// A large value for this means that only a few expensive memcopies will need to be made. A
+/// smaller value means a lot more cheap memcopies will be made.
+const PAGE_SIZE: usize = 64;
 
 /// Byte level memory permission
 ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -327,8 +327,16 @@ impl Mapping {
         for block in &self.dirty {
             let start = block * PAGE_SIZE;
             let end = max_addr.min((block + 1) * PAGE_SIZE);
-            self.data[start..end].copy_from_slice(&original.data[start..end]);
-            self.perms[start..end].copy_from_slice(&original.perms[start..end]);
+
+            // Copy data over
+            let my_data = unsafe { self.data.get_unchecked_mut(start..end) };
+            let orig_data = unsafe { original.data.get_unchecked(start..end) };
+            my_data.copy_from_slice(orig_data);
+
+            // Copy perms over
+            let my_perms = unsafe { self.perms.get_unchecked_mut(start..end) };
+            let orig_perms = unsafe { original.perms.get_unchecked(start..end) };
+            my_perms.copy_from_slice(orig_perms);
             unsafe {
                 *self.dirty_flag.get_unchecked_mut(block / 64) = 0;
             }


### PR DESCRIPTION
Improve overall performance of the crate.

Remove use of `BTreeMap` from the `Mapping` struct. That was tanking performance for resets. Switched to using the same kind of dirty tracking as https://github.com/gamozolabs/fuzz_with_emus.

Also switched to using the unsafe get unchecked methods everywhere that was reasonable to improve performance a little bit.

Will need to update docs or change the API usage of the crate to reflect the potential dangers of some of the functions.